### PR TITLE
SCP titles and Wiki Search

### DIFF
--- a/marvin.py
+++ b/marvin.py
@@ -6,6 +6,8 @@ import random
 import sys
 import configparser
 import os
+import unicodedata
+import spider
 
 config = configparser.ConfigParser()
 config.read('praw.ini')
@@ -24,7 +26,7 @@ desc = "/r/scp helper by one_more_minute"
 
 r = praw.Reddit(user_agent=desc, client_id=config['client_id'], client_secret=config['secret'], username=config['user'], password=config['pass'])
 
-print(r.user.me())
+print("Logged in as: " + str(r.user.me()))
 
 # Get authorisation
 # r.get_authorize_url('foo', 'submit read vote', True)
@@ -34,7 +36,7 @@ def scp_url(num):
 	return "http://www.scp-wiki.net/scp-" + num
 
 def scp_link(num):
-	return "[SCP-" + num + "](" + scp_url(num) + ")"
+	return "[SCP-" + num + "](" + scp_url(num) + ")" + spider.scp_title(num)
 
 existing = set()
 
@@ -103,7 +105,15 @@ def get_quote():
 		return quote
 
 if __name__ == "__main__":
+	spider.update_scip_title_list() 	#updates list of Scips on first run
+	scips = spider.scips			#list of scips and their titles
+	loop_count = 0 			
 	while True:
+		loop_count += 1
+		if loop_count >= 720:		#simple function to refresh list of scips after a period of itme (approx 2 hours, depending on loop delay)
+			loop_count = 0
+			spider.update_scip_title_list()
+			scips = spider.scips
 		sub = '+'.join(['scp', 'InteractiveFoundation', 'SCP_Game', 'sandboxtest', 'SCP682', 'DankMemesFromSite19'])
 		sleep(10)
 		try:

--- a/spider.py
+++ b/spider.py
@@ -1,0 +1,90 @@
+from bs4 import BeautifulSoup
+import re
+from time import time, sleep
+import codecs
+import urllib2
+import os
+
+regex = re.compile("(?<=SCP-)\d+")
+scips = []
+titles = False
+
+def isSCP(i):
+    if i.contents[0].name == 'a':
+        try:
+            return regex.search(i.contents[0].string)
+        except Exception, e:
+            return False
+    else:
+        return False
+
+def scrape_wiki_page(address):    
+    html = urllib2.urlopen(address)
+    soup = BeautifulSoup(html, 'html.parser')
+    li = soup.find_all('li')
+    filteredli = filter(lambda i: isSCP(i), li)
+    for f in filteredli:
+        scips.append([f.contents[0].string, f.contents[1].strip(" - ")])
+    sleep(2)
+
+def update_scip_title_list():
+    pages = ['http://www.scp-wiki.net/scp-series', 'http://www.scp-wiki.net/scp-series-2', 'http://www.scp-wiki.net/scp-series-3', 'http://www.scp-wiki.net/scp-series-4']
+    global scips
+    scips = []
+    global titles
+    try:
+        print "\nUpdating SCP title List"
+        for p in pages:
+            scrape_wiki_page(p)
+        titles = True
+        print "Completed succesfully! Using titles"
+        f = codecs.open('sciplist.txt', encoding='utf-8', mode='w')
+        for l in scips:
+            f.write(l[0] + u"|" + l[1] + u"\r\n")
+        f.close()
+    except Exception, e:
+        print 'Unable to scrape wiki for SCP titles - Error: '
+        print e
+        print 'Trying to recover from backup...'
+        if os.path.isfile('sciplist.txt'):
+            try:
+                f = codecs.open('sciplist.txt', encoding='utf-8', mode='r')
+                tlines = f.read().splitlines()
+                scips = map(lambda a: a.split('|'), tlines)
+                print "Successfully reloaded old SCP title List"
+            except Exception, e:
+                titles = False
+                print "Unable to load from Backup, SCP titles functionality disabled"
+        else:
+            titles = False
+            print "No Backup found, SCP titles functionality disabled"
+
+def scp_title(num):
+    if titles:
+        s = filter(lambda scip: scip[0].find("SCP-" + str(num)) >= 0, scips)
+        if len(s)>0:
+            return " - *'" + s[0][1].encode('ascii','ignore') + "'*"
+        else:
+            return ""
+    else:        
+        return ""
+
+def has_results(tale):
+    address = "http://scp-wiki.wikidot.com/search:site/a/p/q/" + tale.lstrip()
+    address = r"%20".join(address.split(" "))    
+    try:
+        html = urllib2.urlopen(address)
+        soup = BeautifulSoup(html, 'html.parser')
+        divs = soup.find_all('div')
+        divs = filter(lambda d: d.has_attr('class'), divs)
+        divs = filter(lambda d: d['class'][0] == u'search-results', divs)
+        divs = filter(lambda d: d['class'][0] == u'title', divs[0].find_all('div'))
+        divs = divs[0].find_all('a')
+        alink = divs[0]['href'].encode('ascii', 'ignore')
+        astr = []
+        for tag in divs[0].contents:
+            astr.append(tag.string)
+        astr = "".join(astr)
+        return '[' + astr + '](' + alink + ')'
+    except Exception, e:
+        return '"' + tale.lstrip() + '" - No Results'


### PR DESCRIPTION
This is a re-forked version of a previous fork, since the previous one became incompatible because of code updates. The current functionality changes are:

- SCP titles: Adds the title of the SCP that is linked to with the link (i.e. a reply to a query `173` would be `173 - 'The Sculpture'`)

- SCP wiki search: Adds the ability for users to invoke the bot manually to perform a search of the wiki for tales or pages. Can be used by typing a comment in the format `!s <search-query>` or `marvin [... doesn't matter ...] [search/find/get me] <query>`. In either case, the text until the end of line is considered to be the search term. 

- Prettier looking comments using reddit lists instead of just comma separated links, Slightly better back end console output

The technical changes include:

- A beautifulSoup4 based webcrawler which is utilized to perform the wiki search and title functionality. 
- A 'comments_replied_to.txt' file used to store a history of comments that have been replied to and shouldn't be replied to again. 
TODO: Add functionality to automatically prune old comments from the file as it fills up, currently it will fill up till infinity.
